### PR TITLE
Add Premier League club estimator

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,14 @@
         </form>
         <div id="result">Maximum Transfer Spend per Year: £<span id="maxSpend">0</span></div>
         <button onclick="downloadCSV()">Download as CSV</button>
+
+        <div class="club-estimator">
+            <h2>Estimate by Club (v1 AI)</h2>
+            <select id="clubSelect">
+                <option value="">Select a club</option>
+            </select>
+            <div id="clubInfo"></div>
+        </div>
     </div>
     <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -2,6 +2,29 @@ function getRawNumber(el) {
     return parseFloat(el.value.replace(/,/g, "")) || 0;
 }
 
+const clubEstimates = {
+    "Arsenal": { "Operating Loss": "£36m", "Transfer Income": "£74m", "Excludables": "£15m", "Owner Funding": "£55m" },
+    "Aston Villa": { "Operating Loss": "£27m", "Transfer Income": "£57m", "Excludables": "£14m", "Owner Funding": "£22m" },
+    "Bournemouth": { "Operating Loss": "£22m", "Transfer Income": "£97m", "Excludables": "£13m", "Owner Funding": "£102m" },
+    "Brentford": { "Operating Loss": "£44m", "Transfer Income": "£15m", "Excludables": "£12m", "Owner Funding": "£110m" },
+    "Brighton & Hove Albion": { "Operating Loss": "£26m", "Transfer Income": "£15m", "Excludables": "£9m", "Owner Funding": "£148m" },
+    "Burnley": { "Operating Loss": "£28m", "Transfer Income": "£74m", "Excludables": "£13m", "Owner Funding": "£9m" },
+    "Chelsea": { "Operating Loss": "£46m", "Transfer Income": "£8m", "Excludables": "£2m", "Owner Funding": "£146m" },
+    "Crystal Palace": { "Operating Loss": "£29m", "Transfer Income": "£90m", "Excludables": "£5m", "Owner Funding": "£37m" },
+    "Everton": { "Operating Loss": "£77m", "Transfer Income": "£98m", "Excludables": "£13m", "Owner Funding": "£44m" },
+    "Fulham": { "Operating Loss": "£37m", "Transfer Income": "£99m", "Excludables": "£14m", "Owner Funding": "£46m" },
+    "Leeds United": { "Operating Loss": "£31m", "Transfer Income": "£69m", "Excludables": "£13m", "Owner Funding": "£139m" },
+    "Liverpool": { "Operating Loss": "£16m", "Transfer Income": "£100m", "Excludables": "£14m", "Owner Funding": "£83m" },
+    "Manchester City": { "Operating Loss": "£44m", "Transfer Income": "£71m", "Excludables": "£6m", "Owner Funding": "£146m" },
+    "Manchester United": { "Operating Loss": "£54m", "Transfer Income": "£78m", "Excludables": "£11m", "Owner Funding": "£133m" },
+    "Newcastle United": { "Operating Loss": "£46m", "Transfer Income": "£21m", "Excludables": "£3m", "Owner Funding": "£56m" },
+    "Nottingham Forest": { "Operating Loss": "£89m", "Transfer Income": "£94m", "Excludables": "£2m", "Owner Funding": "£115m" },
+    "Sheffield United": { "Operating Loss": "£39m", "Transfer Income": "£46m", "Excludables": "£6m", "Owner Funding": "£85m" },
+    "Tottenham Hotspur": { "Operating Loss": "£13m", "Transfer Income": "£53m", "Excludables": "£10m", "Owner Funding": "£109m" },
+    "West Ham United": { "Operating Loss": "£12m", "Transfer Income": "£96m", "Excludables": "£13m", "Owner Funding": "£97m" },
+    "Wolverhampton Wanderers": { "Operating Loss": "£88m", "Transfer Income": "£59m", "Excludables": "£7m", "Owner Funding": "£80m" }
+};
+
 function calculateMaxSpend() {
     const opInput = document.getElementById("operatingLoss");
     const trInput = document.getElementById("transferIncome");
@@ -69,3 +92,33 @@ function downloadCSV() {
     link.download = "psr_transfer_spend.csv";
     link.click();
 }
+
+function populateClubSelect() {
+    const select = document.getElementById("clubSelect");
+    Object.keys(clubEstimates).forEach(club => {
+        const opt = document.createElement("option");
+        opt.value = club;
+        opt.textContent = club;
+        select.appendChild(opt);
+    });
+}
+
+function updateClubInfo() {
+    const club = document.getElementById("clubSelect").value;
+    const infoDiv = document.getElementById("clubInfo");
+    if (!club) {
+        infoDiv.innerHTML = "";
+        return;
+    }
+    const data = clubEstimates[club];
+    infoDiv.innerHTML =
+        `<p><strong>Operating Loss:</strong> ${data["Operating Loss"]}</p>` +
+        `<p><strong>Transfer Income:</strong> ${data["Transfer Income"]}</p>` +
+        `<p><strong>Excludables:</strong> ${data["Excludables"]}</p>` +
+        `<p><strong>Owner Funding:</strong> ${data["Owner Funding"]}</p>`;
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+    populateClubSelect();
+    document.getElementById("clubSelect").addEventListener("change", updateClubInfo);
+});

--- a/styles.css
+++ b/styles.css
@@ -66,6 +66,18 @@ button:hover {
     font-weight: 300;
 }
 
+.club-estimator {
+    margin-top: 2em;
+    background-color: #fafafa;
+    padding: 1em;
+    border-radius: 8px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+#clubInfo p {
+    margin: 0.3em 0;
+}
+
 @media (max-width: 400px) {
     body {
         font-size: 17px;


### PR DESCRIPTION
## Summary
- add dropdown menu and info section to index.html
- create static clubEstimates object and related JS logic
- style the new estimator section

## Testing
- `npm test` *(fails: Could not find package.json)*
- `pytest`